### PR TITLE
fixed: replace spaces with underscores in the filename

### DIFF
--- a/library.js
+++ b/library.js
@@ -280,6 +280,7 @@ function uploadToAzureStorage(filename, rs, callback) {
 			var azKeyPath = azPath.replace(/^\//, "");
 			var ename = path.extname(filename);
 			var oname = path.basename(filename, ename);
+			oname = oname.replace(/\ /g, "_");
 
 			var key = azKeyPath + uniqid.time(oname + '-') + ename ;
 			next(null, key);


### PR DESCRIPTION
There was an linking error when an file name has empty spaces.
So, I edited uploading file name to replace spaces with underscores.